### PR TITLE
Fix crash due to ratelimiter dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This project is a Python script that synchronizes UniFi devices with Snipe-IT. I
 
 *   Python 3.6 or higher
 *   `requests` library
-*   `ratelimiter` library
 *   `tabulate` library
 *   `pyunifi` library
 *   `termcolor` libary

--- a/rate_limit.py
+++ b/rate_limit.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+    This code lovingly borrowed from the now-abandoned ratelimiter by RazerM: https://github.com/RazerM/ratelimiter/blob/master/ratelimiter/_sync.py
+
+    We just need this bit, which isn't subject to the asyncio errors in _async.py
+
+"""
+
+import time
+import functools
+import threading
+import collections
+
+
+class RateLimiter(object):
+
+    """Provides rate limiting for an operation with a configurable number of
+    requests for a time period.
+    """
+
+    def __init__(self, max_calls, period=1.0, callback=None):
+        """Initialize a RateLimiter object which enforces as much as max_calls
+        operations on period (eventually floating) number of seconds.
+        """
+        if period <= 0:
+            raise ValueError('Rate limiting period should be > 0')
+        if max_calls <= 0:
+            raise ValueError('Rate limiting number of calls should be > 0')
+
+        # We're using a deque to store the last execution timestamps, not for
+        # its maxlen attribute, but to allow constant time front removal.
+        self.calls = collections.deque()
+
+        self.period = period
+        self.max_calls = max_calls
+        self.callback = callback
+        self._lock = threading.Lock()
+        self._alock = None
+
+        # Lock to protect creation of self._alock
+        self._init_lock = threading.Lock()
+
+    def __call__(self, f):
+        """The __call__ function allows the RateLimiter object to be used as a
+        regular function decorator.
+        """
+        @functools.wraps(f)
+        def wrapped(*args, **kwargs):
+            with self:
+                return f(*args, **kwargs)
+        return wrapped
+
+    def __enter__(self):
+        with self._lock:
+            # We want to ensure that no more than max_calls were run in the allowed
+            # period. For this, we store the last timestamps of each call and run
+            # the rate verification upon each __enter__ call.
+            if len(self.calls) >= self.max_calls:
+                until = time.time() + self.period - self._timespan
+                if self.callback:
+                    t = threading.Thread(target=self.callback, args=(until,))
+                    t.daemon = True
+                    t.start()
+                sleeptime = until - time.time()
+                if sleeptime > 0:
+                    time.sleep(sleeptime)
+            return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        with self._lock:
+            # Store the last operation timestamp.
+            self.calls.append(time.time())
+
+            # Pop the timestamp list front (ie: the older calls) until the sum goes
+            # back below the period. This is our 'sliding period' window.
+            while self._timespan >= self.period:
+                self.calls.popleft()
+
+    @property
+    def _timespan(self):
+        return self.calls[-1] - self.calls[0]

--- a/snipe.py
+++ b/snipe.py
@@ -1,7 +1,8 @@
 # snipe.py
 import requests
-from ratelimiter import RateLimiter
+from rate_limit import RateLimiter
 from time import sleep
+
 
 class Snipe:
     def __init__(self, api_url, api_key, rate_limit, timeout=30):


### PR DESCRIPTION
Fixes: https://github.com/grokability/UnifiSnipeSync/issues/1

The rate limiting library in use has been long abandoned, and it doesn't
work with newer pythons because of changes to asyncio in 3.11.

It did include a synchronous version of the rate limiter, though, which is fine for
our needs.

There are better rate limiting libraries out there in terms of type of
rate limiter, but I didn't want to adapt them into this code, as most of
the better ones (eg: rush) are very specifically written for limiting
incoming requests, not outgoing ones. Might not be a big deal to do, but
this was even easier. If folks really want better rate limiting in this
tool, we can look into it when the tool is actually functional again.