### PR TITLE
Un-pin requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-requests==2.26.0
-ratelimiter==1.2.0
-tabulate==0.8.9
-pyunifi==2.21
-termcolor==2.2.0
+requests
+ratelimiter
+tabulate
+pyunifi
+termcolor


### PR DESCRIPTION
The requirements are quite out of date, let's be current until we need
not be

Also allows for flexibility in dependency resolution in case of older pythons limiting versions, if we were to pin things to up-to-date versions.